### PR TITLE
Enable direct Gemini screenshot processing

### DIFF
--- a/electron/ipcHandlers.ts
+++ b/electron/ipcHandlers.ts
@@ -242,12 +242,17 @@ export function initializeIpcHandlers(deps: IIpcHandlerDeps): void {
         }
         return { success: false, error: "API key required" };
       }
-      
-      await deps.processingHelper?.processScreenshots()
-      return { success: true }
+
+      const cfg = configHelper.loadConfig();
+      if (cfg.apiProvider === "gemini") {
+        await deps.processingHelper?.processScreenshotsDirectMode();
+      } else {
+        await deps.processingHelper?.processScreenshots();
+      }
+      return { success: true };
     } catch (error) {
-      console.error("Error processing screenshots:", error)
-      return { error: "Failed to process screenshots" }
+      console.error("Error processing screenshots:", error);
+      return { error: "Failed to process screenshots" };
     }
   })
 


### PR DESCRIPTION
## Summary
- implement a helper to send screenshot images directly to Gemini for solution generation
- automatically use this direct mode when the configured provider is Gemini

## Testing
- `npm test`
- `npx tsc -p tsconfig.electron.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_6866d753ded48321afda9f83f336a0c2